### PR TITLE
feat: preserve if/then/else conditionals and extend JSONSchemaType

### DIFF
--- a/.changeset/silent-conditionals-preserve.md
+++ b/.changeset/silent-conditionals-preserve.md
@@ -1,0 +1,5 @@
+---
+'@toomuchdesign/json-schema-fns': minor
+---
+
+Preserve `if` / `then` / `else` conditional branches in `sealSchemaDeep` and `unsealSchemaDeep` (previously these branches were mutated, silently changing which values triggered `then` vs `else`).

--- a/.changeset/widen-type-array-form.md
+++ b/.changeset/widen-type-array-form.md
@@ -1,0 +1,5 @@
+---
+'@toomuchdesign/json-schema-fns': minor
+---
+
+Accept the array form of `type` (e.g. `type: ['object', 'null']`) at the top level of input schemas. Object-shaped functions (`omitProps`, `pickProps`, …) still require the literal `type: 'object'` form.

--- a/README.md
+++ b/README.md
@@ -275,6 +275,12 @@ const result = pipeWith(
 );
 ```
 
+## Supported JSON Schema dialect
+
+The library targets **[JSON Schema Draft-07 (2018)](https://json-schema.org/draft-07)**. Every transformation acts on a small known set of Draft-07 keywords (`type`, `properties`, `patternProperties`, `required`, `additionalProperties`, the combinators `allOf` / `anyOf` / `oneOf` / `not`, and the conditional applicators `if` / `then` / `else`).
+
+**Forward-compatibility is a design property.** Schemas that use newer keywords from [Draft 2019-09](https://json-schema.org/draft/2019-09) or [Draft 2020-12](https://json-schema.org/draft/2020-12) — for example `$defs`, `prefixItems`, `dependentRequired`, `propertyNames`, `$dynamicRef` — pass through the library unchanged: every keyword the library does not explicitly transform rides through via TypeScript's `const` generic + `Omit`-based merge. See [docs/types.md](docs/types.md) for the mechanics.
+
 ## Related projects
 
 - https://github.com/codeperate/json-schema-builder
@@ -284,16 +290,6 @@ const result = pipeWith(
 ## Todo
 
 - Consider exposing a pipe utility
-
-## Dev notes
-
-### Types structure
-
-The types exposed by this library are intentionally simplified to make them more explicit and easier to work with. Specifically, we unwrap generic types only at the top level—this means simplification is applied to non-recursive (non-deep) generics, and nested generic structures are left intact.
-
-As a result, manual validation of output types is required before each release to ensure they match the expected structures. This step is important to prevent subtle type regressions that automated tests may not catch.
-
-If anything in this process is unclear or if there's a better way to integrate type checking into our workflow, feel free to raise it—I'd appreciate any suggestions.
 
 ## Contributing
 

--- a/docs/combinators.md
+++ b/docs/combinators.md
@@ -1,15 +1,16 @@
 # Sealing/Unsealing combinators
 
-JSON Schema [combinators](https://json-schema.org/understanding-json-schema/reference/combining) (`allOf`, `anyOf`, `oneOf`, `not`) compose sub-schemas into logical expressions. Naively adding or removing `additionalProperties: false` inside every sub-schema changes the logical meaning of the schema, so `sealSchemaDeep` / `unsealSchemaDeep` must recurse selectively.
+JSON Schema [combinators](https://json-schema.org/understanding-json-schema/reference/combining) (`allOf`, `anyOf`, `oneOf`, `not`) and [conditional applicators](https://json-schema.org/understanding-json-schema/reference/conditionals) (`if` / `then` / `else`) compose sub-schemas into logical expressions. Naively adding or removing `additionalProperties: false` inside every sub-schema changes the logical meaning of the schema, so `sealSchemaDeep` / `unsealSchemaDeep` must recurse selectively.
 
 ## Decision table
 
-|         | Seal                                                                                                             | Unseal                                                                                                           |
-| ------- | ---------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
-| `allOf` | 🚫 Skip — sealing each option would forbid properties declared in the siblings (their intersection becomes `{}`) | ✅ Recurse — unseal each option                                                                                  |
-| `anyOf` | ✅ Recurse — seal each option                                                                                    | ✅ Recurse — unseal each option                                                                                  |
-| `oneOf` | ✅ Recurse — seal each option                                                                                    | 🚫 Skip — unsealing would let options overlap and break mutual exclusivity                                       |
-| `not`   | 🚫 Skip — sealing the inner schema narrows it, which _widens_ what `not` matches (validation becomes looser)     | 🚫 Skip — unsealing the inner schema widens it, which _narrows_ what `not` matches (validation becomes stricter) |
+|                        | Seal                                                                                                             | Unseal                                                                                                           |
+| ---------------------- | ---------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| `allOf`                | 🚫 Skip — sealing each option would forbid properties declared in the siblings (their intersection becomes `{}`) | ✅ Recurse — unseal each option                                                                                  |
+| `anyOf`                | ✅ Recurse — seal each option                                                                                    | ✅ Recurse — unseal each option                                                                                  |
+| `oneOf`                | ✅ Recurse — seal each option                                                                                    | 🚫 Skip — unsealing would let options overlap and break mutual exclusivity                                       |
+| `not`                  | 🚫 Skip — sealing the inner schema narrows it, which _widens_ what `not` matches (validation becomes looser)     | 🚫 Skip — unsealing the inner schema widens it, which _narrows_ what `not` matches (validation becomes stricter) |
+| `if` / `then` / `else` | 🚫 Skip — sealing the `if` branch tightens its match set, silently changing when `then` / `else` fires           | 🚫 Skip — unsealing the `if` branch broadens its match set, with the same silent shift in branch selection       |
 
 ## Rationale
 
@@ -34,15 +35,26 @@ JSON Schema [combinators](https://json-schema.org/understanding-json-schema/refe
 
 Neither is safe as an automatic transformation, so `not` sub-schemas are left untouched.
 
+### `if` / `then` / `else` — skip in both directions
+
+`if` is a dispatch predicate: when a value matches `if`, the `then` branch applies; otherwise `else` applies. Mutating any of the three sub-schemas shifts which values trigger which branch, with no way to know whether the user wanted the new dispatch:
+
+- **Sealing `if`** tightens its match set, so values that previously triggered `then` now fall through to `else`.
+- **Unsealing `if`** broadens its match set, so values that previously went to `else` now trigger `then`.
+- **Sealing or unsealing `then` / `else`** changes the validation result _within_ the branch, which may or may not be what the user intended depending on whether the conditional was modelling structural strictness or domain rules.
+
+The whole `if` / `then` / `else` triple is treated as a single conditional construct and skipped in both directions to preserve dispatch and branch semantics together.
+
 ## Property-name collisions
 
-When `allOf` / `anyOf` / `oneOf` / `not` appear as literal property names inside `properties` or `patternProperties`, they are **not** combinators — they are field keys. When the `*Child` helper encounters a `properties` / `patternProperties` keyword, it walks the map's values directly (bypassing the combinator-keyword dispatch) so property-named combinators always recurse normally.
+When `allOf` / `anyOf` / `oneOf` / `not` / `if` / `then` / `else` appear as literal property names inside `properties` or `patternProperties`, they are **not** combinators or applicators — they are field keys. When the `*Child` helper encounters a `properties` / `patternProperties` keyword, it walks the map's values directly (bypassing the combinator-keyword dispatch) so property-named combinators always recurse normally.
 
 ## Summary
 
-| Key     | Seal behavior | Unseal behavior |
-| ------- | ------------- | --------------- |
-| `allOf` | skip          | recurse         |
-| `anyOf` | recurse       | recurse         |
-| `oneOf` | recurse       | skip            |
-| `not`   | skip          | skip            |
+| Key                    | Seal behavior | Unseal behavior |
+| ---------------------- | ------------- | --------------- |
+| `allOf`                | skip          | recurse         |
+| `anyOf`                | recurse       | recurse         |
+| `oneOf`                | recurse       | skip            |
+| `not`                  | skip          | skip            |
+| `if` / `then` / `else` | skip          | skip            |

--- a/docs/roadmap-v1.md
+++ b/docs/roadmap-v1.md
@@ -37,13 +37,17 @@ Items here are required to call the release 1.0 with a straight face. Most are n
 
 **Files affected:** [README.md](../README.md), [src/utils/types/definitions.ts](../src/utils/types/definitions.ts), [docs/](.).
 
-**Decision: A (revised).** Declared dialect is JSON Schema 2020-12; Draft-07 schemas continue to work as a subset. **Do not** extend `JSONSchema` to list metadata / validation keywords (`title`, `description`, `$id`, `$defs`, `examples`, `default`, `deprecated`, `readOnly`, `writeOnly`, `const`, `enum`, `dependentRequired`, `propertyNames`, …) — they already ride through `<const Schema extends ...>` literal inference + `MergeRecords<Schema, …>` (`Omit`-based) and listing them in the type changes nothing observable. See [docs/types.md](types.md) for the subset philosophy. The real M1.1 work is:
+**Decision: A (revised).** Declared dialect is **JSON Schema Draft-07 (2018)** — the dialect the library was built against. Forward-compatibility with later drafts (2019-09, 2020-12) is a **design property**, not an add-on: every transformation acts on a small known set of Draft-07 keywords, and every untouched keyword rides through via `<const Schema extends ...>` literal inference + `MergeRecords<Schema, …>` (`Omit`-based). Schemas using post-Draft-07 keywords therefore work in practice — see [docs/types.md](types.md). One explicit forward extension is documented separately: `unsealSchemaDeep` strips `unevaluatedProperties` (Draft 2019-09) alongside `additionalProperties`.
+
+**Do not** extend `JSONSchema` to list metadata / validation keywords (`title`, `description`, `$id`, `$defs`, `examples`, `default`, `deprecated`, `readOnly`, `writeOnly`, `const`, `enum`, `dependentRequired`, `propertyNames`, …) — they already ride through structurally and listing them in the type changes nothing observable.
+
+The real M1.1 work is:
 
 - Widen `type` to `JSONSchemaType | readonly JSONSchemaType[]` so schemas like `type: ['object', 'null']` are accepted at the top level (currently rejected with TS2345).
 - Add `if` / `then` / `else` to the keyword skip dispatch in `sealSchemaDeep` / `unsealSchemaDeep` (runtime + type) — confirmed bug: today these branches get `additionalProperties: false` mutated into them, silently shifting which values trigger `then` vs `else`. Update [docs/combinators.md](combinators.md) accordingly.
-- Document the dialect declaration and subset position in the README (not in the type).
+- Document the dialect declaration, the forward-compat property, and the `unevaluatedProperties` extension in the README (not in the type).
 
-Validator dialect for M1.3 is the 2020-12 meta-schema (`ajv/dist/2020`).
+Validator dialect for M1.3 is the Draft-07 meta-schema (ajv's default export).
 
 ### M1.2 De-experimentalize the `pipe*` API
 
@@ -63,16 +67,16 @@ Validator dialect for M1.3 is the 2020-12 meta-schema (`ajv/dist/2020`).
 
 **Proposal.**
 
-- Add `ajv` (with `ajv-formats` and the 2020-12 meta-schema) as a dev dependency.
+- Add `ajv` (with `ajv-formats`, using the Draft-07 meta-schema — ajv's default export) as a dev dependency.
 - For each fn, add a `test/semantic/<fn>.test.ts` that:
-  1. Compiles the input schema with ajv against the 2020-12 meta-schema (sanity).
+  1. Compiles the input schema with ajv against the Draft-07 meta-schema (sanity).
   2. Compiles the **output** schema with ajv (validity — the key new check).
   3. Defines a small set of fixture instances and asserts the documented semantic delta (e.g., for `omitProps`, instances missing the omitted prop should now validate where they didn't before, if that prop was required).
 - Keep the existing structural tests as-is — they assert type-level behavior too.
 
 **Why this is the single highest-leverage item.** Once ajv is verifying outputs, a whole class of "the types are right but the runtime is subtly wrong" bug becomes a regression instead of a post-release report.
 
-**Decision: A.** Both meta-schema validity and instance semantics per fn. Dev deps: `ajv`, `ajv-formats`. Shared helpers in `test/semantic/utils.ts` (`assertValidSchema`, `assertValidates`). One `test/semantic/<fn>.test.ts` per public function (8 files). Each contains: (1) one assertion that output passes the 2020-12 meta-schema; (2) ~3 fixture instances asserting the documented semantic delta against the input vs. output schema.
+**Decision: A (revised for Draft-07).** Both meta-schema validity and instance semantics per fn. Dev deps: `ajv`, `ajv-formats`. Validator dialect is **Draft-07** (ajv's default export, `import Ajv from 'ajv'`) — matches the dialect declared in M1.1. Shared helpers in `test/semantic/utils.ts` (`assertValidSchema`, `assertValidates`). One `test/semantic/<fn>.test.ts` per public function (8 files). Each contains: (1) one assertion that output passes the Draft-07 meta-schema; (2) ~3 fixture instances asserting the documented semantic delta against the input vs. output schema. Optional follow-up: add a 2020-12 cross-check (`import Ajv2020 from 'ajv/dist/2020'`) as a defense-in-depth signal that the forward-compat property still holds — not gated on 1.0.
 
 ### M1.4 Property-based tests for round-trip laws
 
@@ -258,7 +262,7 @@ The items below are in scope for the 1.0 release. See each section for the decis
 
 **Type & behavior surface**
 
-- **M1.1** Declare 2020-12 dialect (in README, not in the type); widen `type` to `JSONSchemaType | readonly JSONSchemaType[]`; add `if`/`then`/`else` to combinator dispatch ("skip" policy mirroring `not`). Metadata-keyword preservation is structural already — see [docs/types.md](types.md).
+- **M1.1** Declare **Draft-07** dialect (in README, not in the type) with forward-compatibility as a design property; widen `type` to `JSONSchemaType | readonly JSONSchemaType[]`; add `if`/`then`/`else` to combinator dispatch ("skip" policy mirroring `not`). Metadata-keyword preservation is structural already — see [docs/types.md](types.md).
 - **M1.2** De-experimentalize the `pipe*` API; measure depth ceiling across `{pipe-ts, ts-functional-pipe, effect, remeda}` × `{4, 8, 12, 16, 24}` stages; phrase README claim as "at least N stages verified".
 - **M2.1** Ship `omitPropsDeep` (1.0); defer `requirePropsDeep` / `optionalPropsDeep` to 1.x.
 - **M2.2** Ship `renameProps` (1.0); drop `setProp` and `withMeta` (sugar over `mergeProps`).

--- a/docs/roadmap-v1.md
+++ b/docs/roadmap-v1.md
@@ -37,7 +37,13 @@ Items here are required to call the release 1.0 with a straight face. Most are n
 
 **Files affected:** [README.md](../README.md), [src/utils/types/definitions.ts](../src/utils/types/definitions.ts), [docs/](.).
 
-**Decision: A.** Declared dialect is JSON Schema 2020-12; Draft-07 schemas continue to work as a subset. Extend `JSONSchema` to recognize the full 2020-12 keyword set as documented above (metadata, validation, and 2020-12 structural keywords) — no transform logic, keywords ride through `...schema` spreads. Widen `type` to `JSONSchemaType | readonly JSONSchemaType[]` to support array forms (`type: ['string', 'null']`). Add `if`/`then`/`else` to the combinator dispatch in `sealSchemaDeep` / `unsealSchemaDeep` with a "skip" policy (mirrors `not`); update [docs/combinators.md](combinators.md). Validator dialect for M1.3 is the 2020-12 meta-schema (`ajv/dist/2020`).
+**Decision: A (revised).** Declared dialect is JSON Schema 2020-12; Draft-07 schemas continue to work as a subset. **Do not** extend `JSONSchema` to list metadata / validation keywords (`title`, `description`, `$id`, `$defs`, `examples`, `default`, `deprecated`, `readOnly`, `writeOnly`, `const`, `enum`, `dependentRequired`, `propertyNames`, …) — they already ride through `<const Schema extends ...>` literal inference + `MergeRecords<Schema, …>` (`Omit`-based) and listing them in the type changes nothing observable. See [docs/types.md](types.md) for the subset philosophy. The real M1.1 work is:
+
+- Widen `type` to `JSONSchemaType | readonly JSONSchemaType[]` so schemas like `type: ['object', 'null']` are accepted at the top level (currently rejected with TS2345).
+- Add `if` / `then` / `else` to the keyword skip dispatch in `sealSchemaDeep` / `unsealSchemaDeep` (runtime + type) — confirmed bug: today these branches get `additionalProperties: false` mutated into them, silently shifting which values trigger `then` vs `else`. Update [docs/combinators.md](combinators.md) accordingly.
+- Document the dialect declaration and subset position in the README (not in the type).
+
+Validator dialect for M1.3 is the 2020-12 meta-schema (`ajv/dist/2020`).
 
 ### M1.2 De-experimentalize the `pipe*` API
 
@@ -252,7 +258,7 @@ The items below are in scope for the 1.0 release. See each section for the decis
 
 **Type & behavior surface**
 
-- **M1.1** Declare 2020-12 dialect; widen `JSONSchema` to recognize the full 2020-12 keyword set; widen `type` to `JSONSchemaType | readonly JSONSchemaType[]`; add `if`/`then`/`else` to combinator dispatch ("skip" policy mirroring `not`).
+- **M1.1** Declare 2020-12 dialect (in README, not in the type); widen `type` to `JSONSchemaType | readonly JSONSchemaType[]`; add `if`/`then`/`else` to combinator dispatch ("skip" policy mirroring `not`). Metadata-keyword preservation is structural already — see [docs/types.md](types.md).
 - **M1.2** De-experimentalize the `pipe*` API; measure depth ceiling across `{pipe-ts, ts-functional-pipe, effect, remeda}` × `{4, 8, 12, 16, 24}` stages; phrase README claim as "at least N stages verified".
 - **M2.1** Ship `omitPropsDeep` (1.0); defer `requirePropsDeep` / `optionalPropsDeep` to 1.x.
 - **M2.2** Ship `renameProps` (1.0); drop `setProp` and `withMeta` (sugar over `mergeProps`).

--- a/docs/types.md
+++ b/docs/types.md
@@ -1,15 +1,25 @@
 # Type philosophy
 
-The internal [`JSONSchema`](../src/utils/types/definitions.ts) type is a **structural subset** of JSON Schema 2020-12, not a reference type. Consumers who need a complete JSON Schema TypeScript reference should pull one from npm (e.g. [`json-schema-to-ts`](https://github.com/ThomasAitken/json-schema-to-ts), [`@types/json-schema`](https://www.npmjs.com/package/@types/json-schema)). This document explains what that means in practice and how to decide when to extend the type.
+The internal [`JSONSchema`](../src/utils/types/definitions.ts) type is a **structural subset** of JSON Schema Draft-07 (2018), not a reference type. Consumers who need a complete JSON Schema TypeScript reference should pull one from npm (e.g. [`json-schema-to-ts`](https://github.com/ThomasAribart/json-schema-to-ts), [`@types/json-schema`](https://www.npmjs.com/package/@types/json-schema)). This document explains what that means in practice, why forward-compatibility with later drafts (2019-09, 2020-12) falls out of the design, and how to decide when to extend the type.
 
 ## The subset rule
 
 `JSONSchema` lists only the keywords this library actively reads or writes:
 
 - Object structure: `type`, `properties`, `patternProperties`, `required`, `additionalProperties`, `unevaluatedProperties`
-- Combinators: `allOf`, `anyOf`, `oneOf`, `not` (plus `if` / `then` / `else` once M1.1 ships)
+- Combinators: `allOf`, `anyOf`, `oneOf`, `not`
+- Conditional applicators: `if`, `then`, `else`
 
 Every other JSON Schema keyword (`title`, `description`, `$id`, `$defs`, `examples`, `default`, `deprecated`, `readOnly`, `writeOnly`, `const`, `enum`, `dependentRequired`, `propertyNames`, …) is intentionally **not** in the type. That is deliberate — not an oversight.
+
+## Forward-compatibility is a design property
+
+The library is built against Draft-07 but works in practice with schemas from Draft 2019-09 and Draft 2020-12 too. That isn't a separate compatibility layer — it falls out of the subset rule:
+
+1. Every transformation acts on a small known set of Draft-07 keywords.
+2. Every untouched key rides through structurally (see next section).
+
+So a schema with `$dynamicRef`, `prefixItems`, or `propertyNames` passes through the library unchanged. We don't validate against the spec, we don't try to "understand" the keyword — we leave it alone. There is exactly one explicit forward extension: `unsealSchemaDeep` strips `unevaluatedProperties` (a Draft 2019-09 keyword) alongside `additionalProperties`. That's documented as part of the function's contract.
 
 ## Why omitted keywords still ride through
 
@@ -56,4 +66,4 @@ Do **not** add a keyword for any of the following reasons:
 
 ## Relationship to `json-schema-to-ts`
 
-The library is designed to pair with `json-schema-to-ts`'s `FromSchema`. The contract is: any `as const` schema literal that is valid under `json-schema-to-ts`'s `JSONSchema` type, and uses only the keywords this library knows how to transform, is accepted as input, and every output remains consumable by `FromSchema`. Keywords outside the library's transformation set ride through untouched, so `FromSchema` sees them on the output exactly as it did on the input.
+The library is designed to pair with `json-schema-to-ts`'s `FromSchema`. The contract is: any `as const` schema literal that is valid under `json-schema-to-ts`'s `JSONSchema` type, and uses only the keywords this library knows how to transform, is accepted as input, and every output remains consumable by `FromSchema`. Keywords outside the library's transformation set — Draft-07 keywords we don't touch, or any post-Draft-07 keyword — ride through untouched, so `FromSchema` sees them on the output exactly as it did on the input.

--- a/docs/types.md
+++ b/docs/types.md
@@ -1,0 +1,59 @@
+# Type philosophy
+
+The internal [`JSONSchema`](../src/utils/types/definitions.ts) type is a **structural subset** of JSON Schema 2020-12, not a reference type. Consumers who need a complete JSON Schema TypeScript reference should pull one from npm (e.g. [`json-schema-to-ts`](https://github.com/ThomasAitken/json-schema-to-ts), [`@types/json-schema`](https://www.npmjs.com/package/@types/json-schema)). This document explains what that means in practice and how to decide when to extend the type.
+
+## The subset rule
+
+`JSONSchema` lists only the keywords this library actively reads or writes:
+
+- Object structure: `type`, `properties`, `patternProperties`, `required`, `additionalProperties`, `unevaluatedProperties`
+- Combinators: `allOf`, `anyOf`, `oneOf`, `not` (plus `if` / `then` / `else` once M1.1 ships)
+
+Every other JSON Schema keyword (`title`, `description`, `$id`, `$defs`, `examples`, `default`, `deprecated`, `readOnly`, `writeOnly`, `const`, `enum`, `dependentRequired`, `propertyNames`, …) is intentionally **not** in the type. That is deliberate — not an oversight.
+
+## Why omitted keywords still ride through
+
+Listing more keywords in `JSONSchema` would not improve preservation. Untouched keys already survive the round trip thanks to two compounding mechanisms:
+
+1. **`<const Schema extends JSONSchemaObject>` captures the full literal type** at the call site. The `extends` is a constraint check on known fields, not a shape filter — extra fields on `Schema` are retained.
+2. **`MergeRecords<Schema, {...}>` is `Omit<Schema, K> & {...}`.** Every key the function does not explicitly override is preserved on the output type.
+
+Example, with the current type definition unchanged:
+
+```ts
+const schema = {
+  type: 'object',
+  $id: 'https://example.com/user',
+  title: 'User',
+  examples: [{ name: 'Ada' }],
+  $defs: { Inner: { type: 'string' } },
+  properties: { name: { type: 'string' }, age: { type: 'number' } },
+  required: ['name'],
+} as const;
+
+const result = omitProps(schema, ['age']);
+// result.$id     → 'https://example.com/user'
+// result.title   → 'User'
+// result.examples → readonly [{ readonly name: 'Ada' }]
+// result.$defs   → { readonly Inner: { readonly type: 'string' } }
+```
+
+All four metadata keywords survive as literal types even though none appear in `JSONSchema`. Adding them to the type would change nothing.
+
+## When to extend `JSONSchema`
+
+Add a keyword to [`src/utils/types/definitions.ts`](../src/utils/types/definitions.ts) only when **the library reads or writes it**. Some triggers:
+
+- A new transformation needs to dispatch on the keyword (e.g. `if` / `then` / `else` joining the combinator skip list).
+- An existing transformation must narrow against the keyword's shape (e.g. recognising `type` as either a literal or an array of literals).
+- The runtime needs to enforce a constraint on the keyword's value type.
+
+Do **not** add a keyword for any of the following reasons:
+
+- "To declare support for a dialect" — that belongs in the README.
+- "To preserve it through transformations" — already happens structurally; see above.
+- "Because the spec lists it" — irrelevant unless the library acts on it.
+
+## Relationship to `json-schema-to-ts`
+
+The library is designed to pair with `json-schema-to-ts`'s `FromSchema`. The contract is: any `as const` schema literal that is valid under `json-schema-to-ts`'s `JSONSchema` type, and uses only the keywords this library knows how to transform, is accepted as input, and every output remains consumable by `FromSchema`. Keywords outside the library's transformation set ride through untouched, so `FromSchema` sees them on the output exactly as it did on the input.

--- a/src/sealSchemaDeep.ts
+++ b/src/sealSchemaDeep.ts
@@ -24,8 +24,13 @@ type SealSchemaDeep<Schema> = Schema extends UnknownArray
       : Schema;
 
 // Dispatch recursion based on the JSON Schema keyword — see docs/combinators.md.
-type SealChild<Keyword, Value> = Keyword extends 'not' | 'allOf'
-  ? Value // skip — sealing would alter combinator semantics
+type SealChild<Keyword, Value> = Keyword extends
+  | 'not'
+  | 'allOf'
+  | 'if'
+  | 'then'
+  | 'else'
+  ? Value // skip — sealing would alter combinator / conditional semantics
   : Keyword extends 'properties' | 'patternProperties'
     ? Value extends UnknownRecord
       ? { [PropertyName in keyof Value]: SealSchemaDeep<Value[PropertyName]> }
@@ -47,7 +52,14 @@ function sealSchema(schema: unknown): unknown {
 }
 
 function sealChild(key: string, value: unknown): unknown {
-  if (key === 'not' || key === 'allOf') return value;
+  if (
+    key === 'not' ||
+    key === 'allOf' ||
+    key === 'if' ||
+    key === 'then' ||
+    key === 'else'
+  )
+    return value;
   if (key === 'properties' || key === 'patternProperties') {
     if (!isRecord(value)) return value;
     const result: Record<string, unknown> = {};
@@ -63,6 +75,8 @@ function sealChild(key: string, value: unknown): unknown {
  * JSON Schema [combinators](https://json-schema.org/understanding-json-schema/reference/combining) are handled selectively to preserve semantics:
  * - `anyOf` / `oneOf`: each option is sealed
  * - `allOf` / `not`: left untouched (sealing would alter validation meaning)
+ * - `if` / `then` / `else`: left untouched (sealing the conditional branches
+ *   would silently change when the `then` / `else` branch fires)
  *
  * See [docs/combinators.md](../docs/combinators.md) for the full rationale.
  *

--- a/src/unsealSchemaDeep.ts
+++ b/src/unsealSchemaDeep.ts
@@ -25,8 +25,13 @@ type UnsealSchemaDeep<Schema> = Schema extends UnknownArray
       : Schema;
 
 // Dispatch recursion based on the JSON Schema keyword — see docs/combinators.md.
-type UnsealChild<Keyword, Value> = Keyword extends 'not' | 'oneOf'
-  ? Value // skip — unsealing would alter combinator semantics
+type UnsealChild<Keyword, Value> = Keyword extends
+  | 'not'
+  | 'oneOf'
+  | 'if'
+  | 'then'
+  | 'else'
+  ? Value // skip — unsealing would alter combinator / conditional semantics
   : Keyword extends 'properties' | 'patternProperties'
     ? Value extends UnknownRecord
       ? {
@@ -55,7 +60,14 @@ function unsealSchema(schema: unknown): unknown {
 }
 
 function unsealChild(key: string, value: unknown): unknown {
-  if (key === 'not' || key === 'oneOf') return value;
+  if (
+    key === 'not' ||
+    key === 'oneOf' ||
+    key === 'if' ||
+    key === 'then' ||
+    key === 'else'
+  )
+    return value;
   if (key === 'properties' || key === 'patternProperties') {
     if (!isRecord(value)) return value;
     const result: Record<string, unknown> = {};
@@ -71,6 +83,8 @@ function unsealChild(key: string, value: unknown): unknown {
  * JSON Schema [combinators](https://json-schema.org/understanding-json-schema/reference/combining) are handled selectively to preserve semantics:
  * - `allOf` / `anyOf`: each option is unsealed
  * - `oneOf` / `not`: left untouched (unsealing would alter validation meaning)
+ * - `if` / `then` / `else`: left untouched (unsealing the conditional branches
+ *   would silently change when the `then` / `else` branch fires)
  *
  * See [docs/combinators.md](../docs/combinators.md) for the full rationale.
  *

--- a/src/utils/types/definitions.ts
+++ b/src/utils/types/definitions.ts
@@ -13,7 +13,7 @@ export type JSONSchemaType =
 export type JSONSchema =
   | boolean
   | Readonly<{
-      type?: JSONSchemaType;
+      type?: JSONSchemaType | readonly JSONSchemaType[];
       required?: readonly string[];
       properties?: Readonly<Record<string, unknown>>;
       patternProperties?: Readonly<Record<string, unknown>>;
@@ -26,6 +26,11 @@ export type JSONSchema =
       anyOf?: readonly JSONSchema[];
       oneOf?: readonly JSONSchema[];
       not?: JSONSchema;
+
+      // Conditional applicators
+      if?: JSONSchema;
+      then?: JSONSchema;
+      else?: JSONSchema;
     }>;
 
 export type JSONSchemaObject = Simplify<

--- a/test/sealSchemaDeep.combinators.test.ts
+++ b/test/sealSchemaDeep.combinators.test.ts
@@ -466,6 +466,106 @@ describe('sealSchemaDeep', () => {
       });
     });
 
+    describe('if / then / else', () => {
+      describe('root combinator', () => {
+        it('ignores conditional branches', () => {
+          const schema = {
+            type: 'object',
+            properties: { country: { type: 'string' } },
+            if: {
+              type: 'object',
+              properties: { country: { const: 'US' } },
+            },
+            then: {
+              type: 'object',
+              properties: { zipcode: { type: 'string' } },
+              required: ['zipcode'],
+            },
+            else: {
+              type: 'object',
+              properties: { postalCode: { type: 'string' } },
+              required: ['postalCode'],
+            },
+          } as const;
+          deepFreeze(schema);
+
+          const actual = sealSchemaDeep(schema);
+          const expected = {
+            type: 'object',
+            additionalProperties: false,
+            properties: { country: { type: 'string' } },
+            if: {
+              type: 'object',
+              properties: { country: { const: 'US' } },
+            },
+            then: {
+              type: 'object',
+              properties: { zipcode: { type: 'string' } },
+              required: ['zipcode'],
+            },
+            else: {
+              type: 'object',
+              properties: { postalCode: { type: 'string' } },
+              required: ['postalCode'],
+            },
+          } as const;
+
+          expect(actual).toEqual(expected);
+          expectTypeOf(actual).toEqualTypeOf(expected);
+        });
+      });
+
+      describe('object property combinator', () => {
+        it('ignores conditional branches nested under properties', () => {
+          const schema = {
+            type: 'object',
+            properties: {
+              conditional: {
+                if: {
+                  type: 'object',
+                  properties: { a: { type: 'string' } },
+                },
+                then: {
+                  type: 'object',
+                  properties: { b: { type: 'string' } },
+                },
+                else: {
+                  type: 'object',
+                  properties: { c: { type: 'string' } },
+                },
+              },
+            },
+          } as const;
+          deepFreeze(schema);
+
+          const actual = sealSchemaDeep(schema);
+          const expected = {
+            type: 'object',
+            additionalProperties: false,
+            properties: {
+              conditional: {
+                if: {
+                  type: 'object',
+                  properties: { a: { type: 'string' } },
+                },
+                then: {
+                  type: 'object',
+                  properties: { b: { type: 'string' } },
+                },
+                else: {
+                  type: 'object',
+                  properties: { c: { type: 'string' } },
+                },
+              },
+            },
+          } as const;
+
+          expect(actual).toEqual(expected);
+          expectTypeOf(actual).toEqualTypeOf(expected);
+        });
+      });
+    });
+
     describe('JSON Schema object with JSON schema combinator prop names', () => {
       it('changes object properties', () => {
         const schema = {

--- a/test/unsealSchemaDeep.combinators.test.ts
+++ b/test/unsealSchemaDeep.combinators.test.ts
@@ -490,6 +490,118 @@ describe('unsealSchemaDeep', () => {
       });
     });
 
+    describe('if / then / else', () => {
+      describe('as root definition', () => {
+        it('ignores conditional branches', () => {
+          const schema = {
+            type: 'object',
+            additionalProperties: false,
+            properties: { country: { type: 'string' } },
+            if: {
+              type: 'object',
+              additionalProperties: false,
+              properties: { country: { const: 'US' } },
+            },
+            then: {
+              type: 'object',
+              additionalProperties: false,
+              properties: { zipcode: { type: 'string' } },
+              required: ['zipcode'],
+            },
+            else: {
+              type: 'object',
+              additionalProperties: false,
+              properties: { postalCode: { type: 'string' } },
+              required: ['postalCode'],
+            },
+          } as const;
+          deepFreeze(schema);
+
+          const actual = unsealSchemaDeep(schema);
+          const expected = {
+            type: 'object',
+            properties: { country: { type: 'string' } },
+            if: {
+              type: 'object',
+              additionalProperties: false,
+              properties: { country: { const: 'US' } },
+            },
+            then: {
+              type: 'object',
+              additionalProperties: false,
+              properties: { zipcode: { type: 'string' } },
+              required: ['zipcode'],
+            },
+            else: {
+              type: 'object',
+              additionalProperties: false,
+              properties: { postalCode: { type: 'string' } },
+              required: ['postalCode'],
+            },
+          } as const;
+
+          expect(actual).toEqual(expected);
+          expectTypeOf(actual).toEqualTypeOf(expected);
+        });
+      });
+
+      describe('as object property definition', () => {
+        it('ignores conditional branches nested under properties', () => {
+          const schema = {
+            type: 'object',
+            additionalProperties: false,
+            properties: {
+              conditional: {
+                if: {
+                  type: 'object',
+                  additionalProperties: false,
+                  properties: { a: { type: 'string' } },
+                },
+                then: {
+                  type: 'object',
+                  additionalProperties: false,
+                  properties: { b: { type: 'string' } },
+                },
+                else: {
+                  type: 'object',
+                  additionalProperties: false,
+                  properties: { c: { type: 'string' } },
+                },
+              },
+            },
+          } as const;
+          deepFreeze(schema);
+
+          const actual = unsealSchemaDeep(schema);
+          const expected = {
+            type: 'object',
+            properties: {
+              conditional: {
+                if: {
+                  type: 'object',
+                  additionalProperties: false,
+                  properties: { a: { type: 'string' } },
+                },
+                then: {
+                  type: 'object',
+                  additionalProperties: false,
+                  properties: { b: { type: 'string' } },
+                },
+                else: {
+                  type: 'object',
+                  additionalProperties: false,
+                  properties: { c: { type: 'string' } },
+                },
+              },
+            },
+          } as const;
+
+          expect(actual).toEqual(expected);
+          expectTypeOf(actual).toEqualTypeOf(expected);
+        });
+      });
+    });
+
     describe('JSON Schema object with JSON schema combinator prop names', () => {
       it('changes object properties', () => {
         const schema = {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix + feature

## What is the current behaviour?

`sealSchemaDeep` / `unsealSchemaDeep` were mutating `if` / `then` / `else` sub-schemas, silently changing which values triggered each branch.

## What is the new behaviour?

Add the three keywords to the skip dispatch (runtime + type), mirroring `not`.

Widen the top-level `type` field to `JSONSchemaType | readonly JSONSchemaType[]` so schemas like `type: ['object', 'null']` are accepted at the input boundary (previously rejected with TS2345). `JSONSchemaObject` still requires the literal `'object'` form, so object-shaped functions are unaffected.

## Does this PR introduce a breaking change?

No

## Other information:

## Please check if the PR fulfills these requirements:

- [X] Tests for the changes have been added
- [X] Docs have been added / updated
- [X] Relevant [Changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) has been added
