### PR TITLE
test: assert ajv Draft-07 schema validity on every fixture

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,8 @@
         "@tsconfig/node20": "^20.1.6",
         "@types/deep-freeze": "^0.1.5",
         "@vitest/coverage-v8": "^4.0.1",
+        "ajv": "^8.20.0",
+        "ajv-formats": "^3.0.1",
         "deep-freeze": "^0.0.1",
         "effect": "^3.18.4",
         "json-schema-to-ts": "^3.1.1",
@@ -1219,6 +1221,41 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/ansi-colors": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
@@ -1540,6 +1577,13 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fast-glob": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
@@ -1556,6 +1600,23 @@
       "engines": {
         "node": ">=8.6.0"
       }
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fastq": {
       "version": "1.20.1",
@@ -1930,6 +1991,13 @@
       "engines": {
         "node": ">=16"
       }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/jsonfile": {
       "version": "4.0.0",
@@ -2719,6 +2787,16 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/remeda"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve-from": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,8 @@
     "@tsconfig/node20": "^20.1.6",
     "@types/deep-freeze": "^0.1.5",
     "@vitest/coverage-v8": "^4.0.1",
+    "ajv": "^8.20.0",
+    "ajv-formats": "^3.0.1",
     "deep-freeze": "^0.0.1",
     "effect": "^3.18.4",
     "json-schema-to-ts": "^3.1.1",

--- a/test/assertValidSchema.ts
+++ b/test/assertValidSchema.ts
@@ -1,0 +1,24 @@
+import Ajv, { type AnySchema } from 'ajv';
+import addFormats from 'ajv-formats';
+
+const ajv = new Ajv({ strict: false, allErrors: true });
+addFormats(ajv);
+
+/**
+ * Asserts that `schema` is itself a valid JSON Schema under the Draft-07
+ * meta-schema — the dialect declared in M1.1 of the v1 roadmap.
+ *
+ * Pair with the existing `toEqual` / `expectTypeOf` assertions to guarantee
+ * every output of a public function is a real schema, not just structurally
+ * equal to a fixture.
+ */
+export function assertValidSchema(schema: unknown): void {
+  const valid = ajv.validateSchema(schema as AnySchema);
+  if (!valid) {
+    throw new Error(
+      `Schema is not valid under the Draft-07 meta-schema:\n${ajv.errorsText(
+        ajv.errors,
+      )}`,
+    );
+  }
+}

--- a/test/composition-fns-combinations.test.ts
+++ b/test/composition-fns-combinations.test.ts
@@ -15,6 +15,7 @@ import {
   requireProps,
   sealSchemaDeep,
 } from '../src';
+import { assertValidSchema } from './assertValidSchema';
 
 describe('composition', () => {
   describe('functional API', () => {
@@ -53,6 +54,8 @@ describe('composition', () => {
 
       expect(actual).toEqual(expected);
       expectTypeOf(actual).toEqualTypeOf(expected);
+      assertValidSchema(actual);
+      assertValidSchema(expected);
     });
   });
 
@@ -91,6 +94,8 @@ describe('composition', () => {
 
         expect(actual).toEqual(expected);
         expectTypeOf(actual).toEqualTypeOf(expected);
+        assertValidSchema(actual);
+        assertValidSchema(expected);
       });
     });
 
@@ -128,6 +133,8 @@ describe('composition', () => {
 
         expect(actual).toEqual(expected);
         expectTypeOf(actual).toEqualTypeOf(expected);
+        assertValidSchema(actual);
+        assertValidSchema(expected);
       });
     });
 
@@ -165,6 +172,8 @@ describe('composition', () => {
 
         expect(actual).toEqual(expected);
         expectTypeOf(actual).toEqualTypeOf(expected);
+        assertValidSchema(actual);
+        assertValidSchema(expected);
       });
     });
   });

--- a/test/composition-pipe-deep-recursion.test.ts
+++ b/test/composition-pipe-deep-recursion.test.ts
@@ -4,6 +4,7 @@ import { pipeWith } from 'pipe-ts';
 import { describe, expect, it } from 'vitest';
 
 import { pipeMergeProps, pipeSealSchemaDeep } from '../src';
+import { assertValidSchema } from './assertValidSchema';
 import { largeSchema } from './composition-pipe-deep-recursion-mock';
 
 describe('composition', () => {
@@ -47,6 +48,8 @@ describe('composition', () => {
 
       expect(actual).toEqual(expected);
       expectTypeOf(actual).toEqualTypeOf(expected);
+      assertValidSchema(actual);
+      assertValidSchema(expected);
 
       // Infer types with FromSchema
       type ActualDefinition = FromSchema<typeof actual>;

--- a/test/composition-pipe-packages-interop.test.ts
+++ b/test/composition-pipe-packages-interop.test.ts
@@ -11,6 +11,7 @@ import {
   pipeRequireProps,
   pipeSealSchemaDeep,
 } from '../src';
+import { assertValidSchema } from './assertValidSchema';
 
 describe('composition', () => {
   describe('pipe packages interop', () => {
@@ -48,6 +49,8 @@ describe('composition', () => {
 
         expect(actual).toEqual(expected);
         expectTypeOf(actual).toEqualTypeOf(expected);
+        assertValidSchema(actual);
+        assertValidSchema(expected);
       });
     });
 
@@ -85,6 +88,8 @@ describe('composition', () => {
 
         expect(actual).toEqual(expected);
         expectTypeOf(actual).toEqualTypeOf(expected);
+        assertValidSchema(actual);
+        assertValidSchema(expected);
       });
     });
 
@@ -122,6 +127,8 @@ describe('composition', () => {
 
         expect(actual).toEqual(expected);
         expectTypeOf(actual).toEqualTypeOf(expected);
+        assertValidSchema(actual);
+        assertValidSchema(expected);
       });
     });
 
@@ -159,6 +166,8 @@ describe('composition', () => {
 
         expect(actual).toEqual(expected);
         expectTypeOf(actual).toEqualTypeOf(expected);
+        assertValidSchema(actual);
+        assertValidSchema(expected);
       });
     });
   });

--- a/test/mergeProps.test.ts
+++ b/test/mergeProps.test.ts
@@ -4,6 +4,7 @@ import { pipeWith } from 'pipe-ts';
 import { describe, expect, it } from 'vitest';
 
 import { mergeProps, pipeMergeProps } from '../src';
+import { assertValidSchema } from './assertValidSchema';
 
 describe('mergeProps', () => {
   it('returns expected schema and types', () => {
@@ -59,6 +60,8 @@ describe('mergeProps', () => {
 
     expect(actual).toEqual(expected);
     expectTypeOf(actual).toEqualTypeOf(expected);
+    assertValidSchema(actual);
+    assertValidSchema(expected);
   });
 
   describe('clashing input properties', () => {
@@ -113,6 +116,8 @@ describe('mergeProps', () => {
 
       expect(actual).toEqual(expected);
       expectTypeOf(actual).toEqualTypeOf(expected);
+      assertValidSchema(actual);
+      assertValidSchema(expected);
     });
   });
 
@@ -151,6 +156,8 @@ describe('mergeProps', () => {
 
     expect(actual).toEqual(expected);
     expectTypeOf(actual).toEqualTypeOf(expected);
+    assertValidSchema(actual);
+    assertValidSchema(expected);
   });
 
   describe('no required props on resulting schema', () => {
@@ -182,6 +189,8 @@ describe('mergeProps', () => {
 
       expect(actual).toEqual(expected);
       expectTypeOf(actual).toEqualTypeOf(expected);
+      assertValidSchema(actual);
+      assertValidSchema(expected);
     });
   });
 
@@ -214,6 +223,8 @@ describe('mergeProps', () => {
 
       expect(actual).toEqual(expected);
       expectTypeOf(actual).toEqualTypeOf(expected);
+      assertValidSchema(actual);
+      assertValidSchema(expected);
     });
   });
 
@@ -318,5 +329,7 @@ describe('pipeMergeProps', () => {
 
     expect(actual).toEqual(expected);
     expectTypeOf(actual).toEqualTypeOf(expected);
+    assertValidSchema(actual);
+    assertValidSchema(expected);
   });
 });

--- a/test/omitProps.test.ts
+++ b/test/omitProps.test.ts
@@ -4,6 +4,7 @@ import { pipeWith } from 'pipe-ts';
 import { describe, expect, it } from 'vitest';
 
 import { omitProps, pipeOmitProps } from '../src';
+import { assertValidSchema } from './assertValidSchema';
 
 describe('omitProps', () => {
   it('returns expected schema and types', () => {
@@ -30,6 +31,8 @@ describe('omitProps', () => {
 
     expect(actual).toEqual(expected);
     expectTypeOf(actual).toEqualTypeOf(expected);
+    assertValidSchema(actual);
+    assertValidSchema(expected);
   });
 
   it('preserves non relevant props', () => {
@@ -57,6 +60,8 @@ describe('omitProps', () => {
 
     expect(actual).toEqual(expected);
     expectTypeOf(actual).toEqualTypeOf(expected);
+    assertValidSchema(actual);
+    assertValidSchema(expected);
   });
 
   describe('no required props on resulting schema', () => {
@@ -81,6 +86,8 @@ describe('omitProps', () => {
 
       expect(actual).toEqual(expected);
       expectTypeOf(actual).toEqualTypeOf(expected);
+      assertValidSchema(actual);
+      assertValidSchema(expected);
     });
   });
 
@@ -143,5 +150,7 @@ describe('pipeOmitProps', () => {
 
     expect(actual).toEqual(expected);
     expectTypeOf(actual).toEqualTypeOf(expected);
+    assertValidSchema(actual);
+    assertValidSchema(expected);
   });
 });

--- a/test/optionalProps.test.ts
+++ b/test/optionalProps.test.ts
@@ -4,6 +4,7 @@ import { pipeWith } from 'pipe-ts';
 import { describe, expect, it } from 'vitest';
 
 import { optionalProps, pipeOptionalProps } from '../src';
+import { assertValidSchema } from './assertValidSchema';
 
 describe('optionalProps', () => {
   describe('without keys argument', () => {
@@ -29,6 +30,8 @@ describe('optionalProps', () => {
 
       expect(actual).toEqual(expected);
       expectTypeOf(actual).toEqualTypeOf(expected);
+      assertValidSchema(actual);
+      assertValidSchema(expected);
     });
 
     describe('provided schema.properties prop is empty object', () => {
@@ -48,6 +51,8 @@ describe('optionalProps', () => {
 
         expect(actual).toEqual(expected);
         expectTypeOf(actual).toEqualTypeOf(expected);
+        assertValidSchema(actual);
+        assertValidSchema(expected);
       });
     });
   });
@@ -80,6 +85,8 @@ describe('optionalProps', () => {
 
       expect(actual).toEqual(expected);
       expectTypeOf(actual).toEqualTypeOf(expected);
+      assertValidSchema(actual);
+      assertValidSchema(expected);
     });
 
     describe('keys argument is empty array []', () => {
@@ -99,6 +106,8 @@ describe('optionalProps', () => {
 
         expect(actual).toEqual(expected);
         expectTypeOf(actual).toEqualTypeOf(expected);
+        assertValidSchema(actual);
+        assertValidSchema(expected);
       });
     });
 
@@ -117,6 +126,8 @@ describe('optionalProps', () => {
 
         expect(actual).toEqual(expected);
         expectTypeOf(actual).toEqualTypeOf(expected);
+        assertValidSchema(actual);
+        assertValidSchema(expected);
       });
     });
   });
@@ -183,5 +194,7 @@ describe('optionalProps', () => {
 
     expect(actual).toEqual(expected);
     expectTypeOf(actual).toEqualTypeOf(expected);
+    assertValidSchema(actual);
+    assertValidSchema(expected);
   });
 });

--- a/test/pickProps.test.ts
+++ b/test/pickProps.test.ts
@@ -4,6 +4,7 @@ import { pipeWith } from 'pipe-ts';
 import { describe, expect, it } from 'vitest';
 
 import { pickProps, pipePickProps } from '../src';
+import { assertValidSchema } from './assertValidSchema';
 
 describe('pickProps', () => {
   it('returns expected schema and types', () => {
@@ -32,6 +33,8 @@ describe('pickProps', () => {
 
     expect(actual).toEqual(expected);
     expectTypeOf(actual).toEqualTypeOf(expected);
+    assertValidSchema(actual);
+    assertValidSchema(expected);
   });
 
   it('preserves non relevant props', () => {
@@ -62,6 +65,8 @@ describe('pickProps', () => {
 
     expect(actual).toEqual(expected);
     expectTypeOf(actual).toEqualTypeOf(expected);
+    assertValidSchema(actual);
+    assertValidSchema(expected);
   });
 
   describe('no required props on resulting schema', () => {
@@ -87,6 +92,8 @@ describe('pickProps', () => {
 
       expect(actual).toEqual(expected);
       expectTypeOf(actual).toEqualTypeOf(expected);
+      assertValidSchema(actual);
+      assertValidSchema(expected);
     });
   });
 
@@ -151,5 +158,7 @@ describe('pipePickProps', () => {
 
     expect(actual).toEqual(expected);
     expectTypeOf(actual).toEqualTypeOf(expected);
+    assertValidSchema(actual);
+    assertValidSchema(expected);
   });
 });

--- a/test/pickPropsDeep.test.ts
+++ b/test/pickPropsDeep.test.ts
@@ -4,6 +4,7 @@ import { pipeWith } from 'pipe-ts';
 import { describe, expect, it } from 'vitest';
 
 import { pickPropsDeep, pipePickPropsDeep } from '../src';
+import { assertValidSchema } from './assertValidSchema';
 
 describe('pickPropsDeep', () => {
   it('deep picks a single nested property', () => {
@@ -41,6 +42,8 @@ describe('pickPropsDeep', () => {
 
     expect(actual).toEqual(expected);
     expectTypeOf(actual).toEqualTypeOf(expected);
+    assertValidSchema(actual);
+    assertValidSchema(expected);
   });
 
   it('merges sibling paths under the same prefix', () => {
@@ -80,6 +83,8 @@ describe('pickPropsDeep', () => {
 
     expect(actual).toEqual(expected);
     expectTypeOf(actual).toEqualTypeOf(expected);
+    assertValidSchema(actual);
+    assertValidSchema(expected);
   });
 
   it('combines top-level and nested paths', () => {
@@ -123,6 +128,8 @@ describe('pickPropsDeep', () => {
 
     expect(actual).toEqual(expected);
     expectTypeOf(actual).toEqualTypeOf(expected);
+    assertValidSchema(actual);
+    assertValidSchema(expected);
   });
 
   it('picks the whole sub-schema when a bare key is supplied', () => {
@@ -161,6 +168,8 @@ describe('pickPropsDeep', () => {
 
     expect(actual).toEqual(expected);
     expectTypeOf(actual).toEqualTypeOf(expected);
+    assertValidSchema(actual);
+    assertValidSchema(expected);
   });
 
   it('drills through multiple levels of nesting', () => {
@@ -209,6 +218,8 @@ describe('pickPropsDeep', () => {
 
     expect(actual).toEqual(expected);
     expectTypeOf(actual).toEqualTypeOf(expected);
+    assertValidSchema(actual);
+    assertValidSchema(expected);
   });
 
   it('drills 4 levels deep and prunes siblings at every level', () => {
@@ -272,6 +283,8 @@ describe('pickPropsDeep', () => {
 
     expect(actual).toEqual(expected);
     expectTypeOf(actual).toEqualTypeOf(expected);
+    assertValidSchema(actual);
+    assertValidSchema(expected);
   });
 
   it('drills 5 levels deep and merges sibling paths at a deep level', () => {
@@ -346,6 +359,8 @@ describe('pickPropsDeep', () => {
 
     expect(actual).toEqual(expected);
     expectTypeOf(actual).toEqualTypeOf(expected);
+    assertValidSchema(actual);
+    assertValidSchema(expected);
   });
 
   it('whole-wins at the top level', () => {
@@ -385,6 +400,8 @@ describe('pickPropsDeep', () => {
 
     expect(actual).toEqual(expected);
     expectTypeOf(actual).toEqualTypeOf(expected);
+    assertValidSchema(actual);
+    assertValidSchema(expected);
   });
 
   it('duplicate paths are treated as a single path', () => {
@@ -422,6 +439,8 @@ describe('pickPropsDeep', () => {
 
     expect(actual).toEqual(expected);
     expectTypeOf(actual).toEqualTypeOf(expected);
+    assertValidSchema(actual);
+    assertValidSchema(expected);
   });
 
   it('whole-wins at a deep nested level', () => {
@@ -485,6 +504,8 @@ describe('pickPropsDeep', () => {
 
     expect(actual).toEqual(expected);
     expectTypeOf(actual).toEqualTypeOf(expected);
+    assertValidSchema(actual);
+    assertValidSchema(expected);
   });
 
   it('preserves non relevant props at every level', () => {
@@ -534,6 +555,8 @@ describe('pickPropsDeep', () => {
 
     expect(actual).toEqual(expected);
     expectTypeOf(actual).toEqualTypeOf(expected);
+    assertValidSchema(actual);
+    assertValidSchema(expected);
   });
 
   describe('no required props on resulting schema', () => {
@@ -570,6 +593,8 @@ describe('pickPropsDeep', () => {
 
       expect(actual).toEqual(expected);
       expectTypeOf(actual).toEqualTypeOf(expected);
+      assertValidSchema(actual);
+      assertValidSchema(expected);
     });
 
     it('omits required prop at the root level', () => {
@@ -599,6 +624,8 @@ describe('pickPropsDeep', () => {
 
       expect(actual).toEqual(expected);
       expectTypeOf(actual).toEqualTypeOf(expected);
+      assertValidSchema(actual);
+      assertValidSchema(expected);
     });
   });
 
@@ -622,6 +649,8 @@ describe('pickPropsDeep', () => {
 
       expect(actual).toEqual(expected);
       expectTypeOf(actual).toEqualTypeOf(expected);
+      assertValidSchema(actual);
+      assertValidSchema(expected);
     });
   });
 
@@ -669,6 +698,8 @@ describe('pickPropsDeep', () => {
 
       expect(actual).toEqual(expected);
       expectTypeOf(actual).toEqualTypeOf(expected);
+      assertValidSchema(actual);
+      assertValidSchema(expected);
     });
   });
 
@@ -743,5 +774,7 @@ describe('pipePickPropsDeep', () => {
 
     expect(actual).toEqual(expected);
     expectTypeOf(actual).toEqualTypeOf(expected);
+    assertValidSchema(actual);
+    assertValidSchema(expected);
   });
 });

--- a/test/requireProps.test.ts
+++ b/test/requireProps.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from 'vitest';
 
 import { pipeRequireProps, requireProps } from '../src';
 import type { TupleToUnion } from '../src/utils/types';
+import { assertValidSchema } from './assertValidSchema';
 
 describe('requireProps', () => {
   describe('without keys argument', () => {
@@ -76,6 +77,8 @@ describe('requireProps', () => {
 
         expect(actual).toEqual(expected);
         expectTypeOf(actual).toEqualTypeOf(expected);
+        assertValidSchema(actual);
+        assertValidSchema(expected);
       });
     });
   });
@@ -152,6 +155,8 @@ describe('requireProps', () => {
 
         expect(actual).toEqual(expected);
         expectTypeOf(actual).toEqualTypeOf(expected);
+        assertValidSchema(actual);
+        assertValidSchema(expected);
       });
     });
   });
@@ -177,6 +182,8 @@ describe('requireProps', () => {
 
     expect(actual).toEqual(expected);
     expectTypeOf(actual).toEqualTypeOf(expected);
+    assertValidSchema(actual);
+    assertValidSchema(expected);
   });
 
   describe('type !== object', () => {

--- a/test/sealSchemaDeep.combinators.test.ts
+++ b/test/sealSchemaDeep.combinators.test.ts
@@ -3,6 +3,7 @@ import { expectTypeOf } from 'expect-type';
 import { describe, expect, it } from 'vitest';
 
 import { sealSchemaDeep } from '../src';
+import { assertValidSchema } from './assertValidSchema';
 
 describe('sealSchemaDeep', () => {
   describe('combinators', () => {
@@ -39,6 +40,8 @@ describe('sealSchemaDeep', () => {
 
           expect(actual).toEqual(expected);
           expectTypeOf(actual).toEqualTypeOf(expected);
+          assertValidSchema(actual);
+          assertValidSchema(expected);
         });
       });
 
@@ -125,6 +128,8 @@ describe('sealSchemaDeep', () => {
 
           expect(actual).toEqual(expected);
           expectTypeOf(actual).toEqualTypeOf(expected);
+          assertValidSchema(actual);
+          assertValidSchema(expected);
         });
       });
     });
@@ -164,6 +169,8 @@ describe('sealSchemaDeep', () => {
 
           expect(actual).toEqual(expected);
           expectTypeOf(actual).toEqualTypeOf(expected);
+          assertValidSchema(actual);
+          assertValidSchema(expected);
         });
       });
 
@@ -242,6 +249,8 @@ describe('sealSchemaDeep', () => {
 
           expect(actual).toEqual(expected);
           expectTypeOf(actual).toEqualTypeOf(expected);
+          assertValidSchema(actual);
+          assertValidSchema(expected);
         });
       });
     });
@@ -281,6 +290,8 @@ describe('sealSchemaDeep', () => {
 
           expect(actual).toEqual(expected);
           expectTypeOf(actual).toEqualTypeOf(expected);
+          assertValidSchema(actual);
+          assertValidSchema(expected);
         });
       });
 
@@ -359,6 +370,8 @@ describe('sealSchemaDeep', () => {
 
           expect(actual).toEqual(expected);
           expectTypeOf(actual).toEqualTypeOf(expected);
+          assertValidSchema(actual);
+          assertValidSchema(expected);
         });
       });
     });
@@ -414,6 +427,8 @@ describe('sealSchemaDeep', () => {
 
           expect(actual).toEqual(expected);
           expectTypeOf(actual).toEqualTypeOf(expected);
+          assertValidSchema(actual);
+          assertValidSchema(expected);
         });
       });
 
@@ -462,6 +477,8 @@ describe('sealSchemaDeep', () => {
 
           expect(actual).toEqual(expected);
           expectTypeOf(actual).toEqualTypeOf(expected);
+          assertValidSchema(actual);
+          assertValidSchema(expected);
         });
       });
     });
@@ -512,6 +529,8 @@ describe('sealSchemaDeep', () => {
 
           expect(actual).toEqual(expected);
           expectTypeOf(actual).toEqualTypeOf(expected);
+          assertValidSchema(actual);
+          assertValidSchema(expected);
         });
       });
 
@@ -562,6 +581,8 @@ describe('sealSchemaDeep', () => {
 
           expect(actual).toEqual(expected);
           expectTypeOf(actual).toEqualTypeOf(expected);
+          assertValidSchema(actual);
+          assertValidSchema(expected);
         });
       });
     });
@@ -729,6 +750,8 @@ describe('sealSchemaDeep', () => {
 
         expect(actual).toEqual(expected);
         expectTypeOf(actual).toEqualTypeOf(expected);
+        assertValidSchema(actual);
+        assertValidSchema(expected);
       });
     });
   });

--- a/test/sealSchemaDeep.test.ts
+++ b/test/sealSchemaDeep.test.ts
@@ -4,6 +4,7 @@ import { pipeWith } from 'pipe-ts';
 import { describe, expect, it } from 'vitest';
 
 import { pipeSealSchemaDeep, sealSchemaDeep } from '../src';
+import { assertValidSchema } from './assertValidSchema';
 
 describe('sealSchemaDeep', () => {
   it('recursively set additionalProperties prop to false', () => {
@@ -60,6 +61,8 @@ describe('sealSchemaDeep', () => {
 
     expect(actual).toEqual(expected);
     expectTypeOf(actual).toEqualTypeOf(expected);
+    assertValidSchema(actual);
+    assertValidSchema(expected);
   });
 
   describe('array prop', () => {
@@ -157,6 +160,8 @@ describe('sealSchemaDeep', () => {
 
       expect(actual).toEqual(expected);
       expectTypeOf(actual).toEqualTypeOf(expected);
+      assertValidSchema(actual);
+      assertValidSchema(expected);
     });
   });
 
@@ -195,6 +200,8 @@ describe('sealSchemaDeep', () => {
 
       expect(actual).toEqual(expected);
       expectTypeOf(actual).toEqualTypeOf(expected);
+      assertValidSchema(actual);
+      assertValidSchema(expected);
     });
   });
 });
@@ -235,5 +242,7 @@ describe('pipeSealSchemaDeep', () => {
 
     expect(actual).toEqual(expected);
     expectTypeOf(actual).toEqualTypeOf(expected);
+    assertValidSchema(actual);
+    assertValidSchema(expected);
   });
 });

--- a/test/unsealSchemaDeep.combinators.test.ts
+++ b/test/unsealSchemaDeep.combinators.test.ts
@@ -3,6 +3,7 @@ import { expectTypeOf } from 'expect-type';
 import { describe, expect, it } from 'vitest';
 
 import { unsealSchemaDeep } from '../src';
+import { assertValidSchema } from './assertValidSchema';
 
 describe('unsealSchemaDeep', () => {
   describe('combinators', () => {
@@ -41,6 +42,8 @@ describe('unsealSchemaDeep', () => {
 
           expect(actual).toEqual(expected);
           expectTypeOf(actual).toEqualTypeOf(expected);
+          assertValidSchema(actual);
+          assertValidSchema(expected);
         });
       });
 
@@ -155,6 +158,8 @@ describe('unsealSchemaDeep', () => {
 
           expect(actual).toEqual(expected);
           expectTypeOf(actual).toEqualTypeOf(expected);
+          assertValidSchema(actual);
+          assertValidSchema(expected);
         });
       });
     });
@@ -194,6 +199,8 @@ describe('unsealSchemaDeep', () => {
 
           expect(actual).toEqual(expected);
           expectTypeOf(actual).toEqualTypeOf(expected);
+          assertValidSchema(actual);
+          assertValidSchema(expected);
         });
       });
 
@@ -272,6 +279,8 @@ describe('unsealSchemaDeep', () => {
 
           expect(actual).toEqual(expected);
           expectTypeOf(actual).toEqualTypeOf(expected);
+          assertValidSchema(actual);
+          assertValidSchema(expected);
         });
       });
     });
@@ -309,6 +318,8 @@ describe('unsealSchemaDeep', () => {
 
           expect(actual).toEqual(expected);
           expectTypeOf(actual).toEqualTypeOf(expected);
+          assertValidSchema(actual);
+          assertValidSchema(expected);
         });
       });
 
@@ -391,6 +402,8 @@ describe('unsealSchemaDeep', () => {
 
           expect(actual).toEqual(expected);
           expectTypeOf(actual).toEqualTypeOf(expected);
+          assertValidSchema(actual);
+          assertValidSchema(expected);
         });
       });
     });
@@ -434,6 +447,8 @@ describe('unsealSchemaDeep', () => {
 
           expect(actual).toEqual(expected);
           expectTypeOf(actual).toEqualTypeOf(expected);
+          assertValidSchema(actual);
+          assertValidSchema(expected);
         });
       });
 
@@ -486,6 +501,8 @@ describe('unsealSchemaDeep', () => {
 
           expect(actual).toEqual(expected);
           expectTypeOf(actual).toEqualTypeOf(expected);
+          assertValidSchema(actual);
+          assertValidSchema(expected);
         });
       });
     });
@@ -542,6 +559,8 @@ describe('unsealSchemaDeep', () => {
 
           expect(actual).toEqual(expected);
           expectTypeOf(actual).toEqualTypeOf(expected);
+          assertValidSchema(actual);
+          assertValidSchema(expected);
         });
       });
 
@@ -598,6 +617,8 @@ describe('unsealSchemaDeep', () => {
 
           expect(actual).toEqual(expected);
           expectTypeOf(actual).toEqualTypeOf(expected);
+          assertValidSchema(actual);
+          assertValidSchema(expected);
         });
       });
     });
@@ -765,6 +786,8 @@ describe('unsealSchemaDeep', () => {
 
         expect(actual).toEqual(expected);
         expectTypeOf(actual).toEqualTypeOf(expected);
+        assertValidSchema(actual);
+        assertValidSchema(expected);
       });
     });
   });

--- a/test/unsealSchemaDeep.test.ts
+++ b/test/unsealSchemaDeep.test.ts
@@ -4,6 +4,7 @@ import { pipeWith } from 'pipe-ts';
 import { describe, expect, it } from 'vitest';
 
 import { pipeUnsealSchemaDeep, unsealSchemaDeep } from '../src';
+import { assertValidSchema } from './assertValidSchema';
 
 describe('unsealSchemaDeep', () => {
   it('recursively removes additionalProperties and unevaluatedProperties props', () => {
@@ -104,6 +105,8 @@ describe('unsealSchemaDeep', () => {
 
     expect(actual).toEqual(expected);
     expectTypeOf(actual).toEqualTypeOf(expected);
+    assertValidSchema(actual);
+    assertValidSchema(expected);
   });
 
   describe('array prop', () => {
@@ -212,6 +215,8 @@ describe('unsealSchemaDeep', () => {
 
       expect(actual).toEqual(expected);
       expectTypeOf(actual).toEqualTypeOf(expected);
+      assertValidSchema(actual);
+      assertValidSchema(expected);
     });
   });
 
@@ -238,6 +243,8 @@ describe('unsealSchemaDeep', () => {
 
       expect(actual).toEqual(expected);
       expectTypeOf(actual).toEqualTypeOf(expected);
+      assertValidSchema(actual);
+      assertValidSchema(expected);
     });
   });
 
@@ -321,5 +328,7 @@ describe('pipeUnsealSchemaDeep', () => {
 
     expect(actual).toEqual(expected);
     expectTypeOf(actual).toEqualTypeOf(expected);
+    assertValidSchema(actual);
+    assertValidSchema(expected);
   });
 });


### PR DESCRIPTION
## What kind of change does this PR introduce?

Tests

## What is the new behaviour?

Adds a shared `assertValidSchema` test helper backed by ajv and calls it on every actual/expected pair in the existing test suite, so the runtime output of each public function is verified as a real Draft-07 schema.

## Does this PR introduce a breaking change?

No

## Other information:

## Please check if the PR fulfills these requirements:

- [X] Tests for the changes have been added
- [ ] Docs have been added / updated
- [ ] Relevant [Changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) has been added
